### PR TITLE
Update jsoup to avoid vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.7.2</version>
+            <version>1.8.3</version>
         </dependency>
         <dependency>
             <groupId>com.ibm.icu</groupId>


### PR DESCRIPTION
Affected versions of the package jsoup prior to 1.8.3 are vulnerable to Cross-site Scripting (XSS) attacks which occurred due to of improperly handling tags without a closing > when reaching EOF. JSoup did not properly validate user-supplied HTML content. Certain HTML snippets could get past the validator without being detected as unsafe. A remote attacker could use a specially crafted HTML snippet to execute arbitrary web script in the user's browser.
CVE has published that Cross-site scripting (XSS) vulnerability is possible in jsoup before 1.8.3. To avoid this, it is recomended to upgrade jsoup to v1.8.3